### PR TITLE
Field error

### DIFF
--- a/static/js/base.js
+++ b/static/js/base.js
@@ -317,9 +317,24 @@ function uploadObjects(){
     if (mode === "idle") {
         clearCanvas();
     }
-    objectsCode = cmObjects.getValue();
-    localStorage.setItem("objectsCode", objectsCode);
-    worker.postMessage({objectsCode:objectsCode, manualUpload:true});
+
+    try {
+        newObjCode = cmObjects.getValue();
+        let returnString = "return " + newObjCode;
+        let f = new Function(returnString);
+        let objects = f();
+        worker.postMessage({objects:objects});
+
+        log("Field upload successful")
+        localStorage.setItem("objectsCode", newObjCode);
+    } catch(err) {
+        let returnString = "return " + objectsCode;
+        let f = new Function(returnString);
+        let objects = f();
+        worker.postMessage({objects:objects});
+        log(err.toString());
+    }
+
     if (mode === "auto") {
         log("Autonomous simulation active: Field will update when next simulation starts")
     }
@@ -337,7 +352,17 @@ function uploadObjects(){
 
 function uploadObjectsOnce() {
     if (objectsCode !== null) {
-        worker.postMessage({objectsCode:objectsCode});
+        try {
+            let returnString = "return " + objectsCode;
+            let f = new Function(returnString);
+            let objects = f();
+            worker.postMessage({objects:objects});
+        } catch(err) {
+            let f = new Function(returnString);
+            let objects = f();
+            worker.postMessage({objects:objects});
+            log(err.toString());
+        }
     } else {
         setTimeout(uploadObjectsOnce, 100);
     }
@@ -383,7 +408,17 @@ function start(auto=false) {
         clearInterval(timer);
         if (codeUploaded) {
             // Send the list of objects
-            worker.postMessage({objectsCode:objectsCode});
+            try {
+                let returnString = "return " + objectsCode;
+                let f = new Function(returnString);
+                let objects = f();
+                worker.postMessage({objects:objects});
+            } catch(err) {
+                let f = new Function(returnString);
+                let objects = f();
+                worker.postMessage({objects:objects});
+                log(err.toString());
+            }
 
             //  Collect the robot start position and direction
             let robotInfo = {
@@ -486,7 +521,7 @@ function log(text) {
     const time = '[' + ((hour < 10) ? '0' + hour: hour) + ':' + ((minutes < 10) ? '0' + minutes: minutes) + '] ';
 
     let consoleLog = document.getElementById("console");
-    if (text.includes("Python exception:")) {
+    if (text.includes("Python exception:") || text.includes("SyntaxError:")) {
         pythonError = true;
     }
     if (pythonError) {

--- a/static/js/base.js
+++ b/static/js/base.js
@@ -319,7 +319,7 @@ function uploadObjects(){
     }
     objectsCode = cmObjects.getValue();
     localStorage.setItem("objectsCode", objectsCode);
-    worker.postMessage({objectsCode:objectsCode, firstCodeUpload:true});
+    worker.postMessage({objectsCode:objectsCode, manualUpload:true});
     if (mode === "auto") {
         log("Autonomous simulation active: Field will update when next simulation starts")
     }

--- a/static/js/base.js
+++ b/static/js/base.js
@@ -319,11 +319,9 @@ function uploadObjects(){
     }
     objectsCode = cmObjects.getValue();
     localStorage.setItem("objectsCode", objectsCode);
-    worker.postMessage({objectsCode:objectsCode});
+    worker.postMessage({objectsCode:objectsCode, firstCodeUpload:true});
     if (mode === "auto") {
         log("Autonomous simulation active: Field will update when next simulation starts")
-    } else {
-        log("Field upload successful");
     }
     if (mode === "idle") {
         // Redraw robot

--- a/static/js/robot.js
+++ b/static/js/robot.js
@@ -1103,7 +1103,7 @@ this.onmessage = function(e) {
           let objects = f();
           simulator.defineObjs(objects);
 
-          if (e.data.manualUpload !== undefined) {
+          if (e.data.manualUpload) {
             console.log("Field upload successful")
           }
       } catch(err) {

--- a/static/js/robot.js
+++ b/static/js/robot.js
@@ -1103,11 +1103,11 @@ this.onmessage = function(e) {
           let objects = f();
           simulator.defineObjs(objects);
 
-          if (e.data.firstCodeUpload !== undefined) {
+          if (e.data.manualUpload !== undefined) {
             console.log("Field upload successful")
           }
       } catch(err) {
-          console.log("Error uploading code. Please check syntax.");
+          console.log(err.toString());
       }
       // Draw objects if no active simulation
       if (simulator.mode == "idle") {

--- a/static/js/robot.js
+++ b/static/js/robot.js
@@ -1096,29 +1096,18 @@ this.onmessage = function(e) {
         code = e.data.code;
     }
     // Give simulator the list of objects
-    if (e.data.objectsCode !== undefined) {
-      try {
-          let returnString = "return " + e.data.objectsCode;
-          let f = new Function(returnString);
-          let objects = f();
-          simulator.defineObjs(objects);
+    if (e.data.objects !== undefined) {
+        simulator.defineObjs(e.data.objects);
+        // Draw objects if no active simulation
+        if (simulator.mode == "idle") {
+            simulator.drawObjs();
+        }
 
-          if (e.data.manualUpload) {
-            console.log("Field upload successful")
-          }
-      } catch(err) {
-          console.log(err.toString());
-      }
-      // Draw objects if no active simulation
-      if (simulator.mode == "idle") {
-          simulator.drawObjs();
-      }
-
-      // Objects get redefined right away in teleop mode.
-      // Attached objects get removed, so set to null.
-      if (simulator.mode == "teleop") {
-          simulator.robot.attachedObj = null;
-      }
+        // Objects get redefined right away in teleop mode.
+        // Attached objects get removed, so set to null.
+        if (simulator.mode == "teleop") {
+            simulator.robot.attachedObj = null;
+        }
     }
 
     if (e.data.start === true) {

--- a/static/js/robot.js
+++ b/static/js/robot.js
@@ -1103,24 +1103,22 @@ this.onmessage = function(e) {
           let objects = f();
           simulator.defineObjs(objects);
 
-          // Draw objects if no active simulation
-          if (simulator.mode == "idle") {
-              simulator.drawObjs();
-          }
-
-          // Objects get redefined right away in teleop mode.
-          // Attached objects get removed, so set to null.
-          if (simulator.mode == "teleop") {
-              simulator.robot.attachedObj = null;
-          }
-
           if (e.data.firstCodeUpload !== undefined) {
             console.log("Field upload successful")
           }
       } catch(err) {
           console.log("Error uploading code. Please check syntax.");
       }
+      // Draw objects if no active simulation
+      if (simulator.mode == "idle") {
+          simulator.drawObjs();
+      }
 
+      // Objects get redefined right away in teleop mode.
+      // Attached objects get removed, so set to null.
+      if (simulator.mode == "teleop") {
+          simulator.robot.attachedObj = null;
+      }
     }
 
     if (e.data.start === true) {

--- a/static/js/robot.js
+++ b/static/js/robot.js
@@ -1097,21 +1097,30 @@ this.onmessage = function(e) {
     }
     // Give simulator the list of objects
     if (e.data.objectsCode !== undefined) {
-        let returnString = "return " + e.data.objectsCode;
-        let f = new Function(returnString);
-        let objects = f();
-        simulator.defineObjs(objects);
+      try {
+          let returnString = "return " + e.data.objectsCode;
+          let f = new Function(returnString);
+          let objects = f();
+          simulator.defineObjs(objects);
 
-        // Draw objects if no active simulation
-        if (simulator.mode == "idle") {
-            simulator.drawObjs();
-        }
+          // Draw objects if no active simulation
+          if (simulator.mode == "idle") {
+              simulator.drawObjs();
+          }
 
-        // Objects get redefined right away in teleop mode.
-        // Attached objects get removed, so set to null.
-        if (simulator.mode == "teleop") {
-            simulator.robot.attachedObj = null;
-        }
+          // Objects get redefined right away in teleop mode.
+          // Attached objects get removed, so set to null.
+          if (simulator.mode == "teleop") {
+              simulator.robot.attachedObj = null;
+          }
+
+          if (e.data.firstCodeUpload !== undefined) {
+            console.log("Field upload successful")
+          }
+      } catch(err) {
+          console.log("Error uploading code. Please check syntax.");
+      }
+
     }
 
     if (e.data.start === true) {


### PR DESCRIPTION
Field upload will send a message to the console if there is a syntax error in the field codebox
* If error on page load, field will be blank
* Otherwise, a field upload error will keep the previous working field structure

Field upload message moved to `robot.js`
* Still only logs message for uploads besides page load
* Logs either a successful message or fail message, not both